### PR TITLE
Don't leave zombie bun processes

### DIFF
--- a/lib/bun.ex
+++ b/lib/bun.ex
@@ -161,8 +161,13 @@ defmodule Bun do
       stderr_to_stdout: true
     ]
 
-    bin_path()
-    |> System.cmd(args ++ extra_args, opts)
+    # If we launch the bun process directly, it will keep running as a zombie process even after
+    # closing the parent Elixir process. To avoid this issue we wrap the application in a script
+    # that checks for stdin to ensure bun is closed.
+    watcher_path = Path.join(:code.priv_dir(:elixir_bun), "bun_launcher.sh")
+
+    watcher_path
+    |> System.cmd([bin_path()] ++ args ++ extra_args, opts)
     |> elem(1)
   end
 

--- a/priv/bun_launcher.sh
+++ b/priv/bun_launcher.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# This script has been taken from https://hexdocs.pm/elixir/main/Port.html#module-zombie-operating-system-processes
+
+# Start the program in the background
+exec "$@" &
+pid1=$!
+
+# Silence warnings from here on
+exec >/dev/null 2>&1
+
+# Read from stdin in the background and
+# kill running program when stdin closes
+exec 0<&0 $(
+  while read; do :; done
+  kill -KILL $pid1
+) &
+pid2=$!
+
+# Clean up
+wait $pid1
+ret=$?
+kill -KILL $pid2
+exit $ret


### PR DESCRIPTION
This PR adds a script that wraps the `bun` process to ensure that it is closed along with the parent Elixir application. The script was taken from the [Elixir Port docs](https://hexdocs.pm/elixir/main/Port.html#module-zombie-operating-system-processes).

This should hopefully fix #4