### PR TITLE
Point CHANGELOG to GitHub releases page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,3 @@
-# CHANGELOG
+# Changelog
 
-## v0.1.4 (2023-10-21)
-
-* Update to Bun 1.0.7 by [@crbelaus](https://github.com/crbelaus)
-* Don't leave zombie Bun processes after closing the Elixir process [@crbelaus](https://github.com/crbelaus) in #5
-* Add a logo to the project by [@pepicrft](https://github.com/pepicrft) in #1
-* Suggest using symlinks instead of copying Phoenix dependencies by [@LostKobrakai](https://github.com/LostKobrakai) in #3
-
-
-## v0.1.3 (2023-09-16)
-
-  * Remove latest esbuild references
-
-## v0.1.2 (2023-09-15)
-
-  * Update to Bun 1.0.2
-  * Add CHANGELOG
-
-## v0.1.1 (2023-09-15)
-
-  * Minor fixes in README
-
-## v0.1.0 (2023-09-15)
-
-  * First release
+Please see [our GitHub "Releases" page](https://github.com/crbelaus/elixir_bun/releases).


### PR DESCRIPTION
The GitHub releases page provides richer diffs and more information than the raw changelog file.